### PR TITLE
Fix drift after completion

### DIFF
--- a/LTPlanner.m
+++ b/LTPlanner.m
@@ -603,6 +603,9 @@ classdef LTPlanner < handle
             %% Calculate acceleration trajectories
             a_traj = obj.Tsample * cumsum(j_traj,2) + a_0;
 
+            % Set final acceleration to exactly 0 (increases accuracy)
+            a_traj(joint,sampled_t(joint,7)+1:end) = 0;
+
             %% Calculate velocitie trajectories
             v_traj = obj.Tsample * cumsum(a_traj,2) + v_0;
 

--- a/LTPlanner.m
+++ b/LTPlanner.m
@@ -614,7 +614,7 @@ classdef LTPlanner < handle
                 end
 
                 % Set final velocity to exactly 0 (increases accuracy)
-                v_traj(joint,sampled_t(joint,7):end) = 0;
+                v_traj(joint,sampled_t(joint,7)+1:end) = 0;
             end
 
             %% Calculate joint angle trajectories

--- a/LTPlanner.m
+++ b/LTPlanner.m
@@ -612,6 +612,9 @@ classdef LTPlanner < handle
                 if const_v(joint)
                     v_traj(joint,sampled_t(joint,3)+1:sampled_t(joint,4)-1) = v_drive(joint) * dir(joint);
                 end
+
+                % Set final velocity to exactly 0 (increases accuracy)
+                v_traj(joint,sampled_t(joint,7):end) = 0;
             end
 
             %% Calculate joint angle trajectories

--- a/src/long_term_planner.cc
+++ b/src/long_term_planner.cc
@@ -820,7 +820,7 @@ Trajectory LongTermPlanner::getTrajectory(
         v_traj[joint][i] = v_traj[joint][i-1] + t_sample_ * a_traj[joint][i];
       } else {
         // Set final velocity to exactly 0 (increases accuracy)
-        v_traj[joint][i] = 0.0
+        v_traj[joint][i] = 0.0;
       }
       q_traj[joint][i] = q_traj[joint][i-1] + t_sample_ * v_traj[joint][i];
     }

--- a/src/long_term_planner.cc
+++ b/src/long_term_planner.cc
@@ -816,8 +816,11 @@ Trajectory LongTermPlanner::getTrajectory(
       // Set constant velocity periods to exactly v_drive (increases accuracy)
       if (phase4 && i >= sampled_t[joint][2]+1 && i< sampled_t[joint][3]-1) {
         v_traj[joint][i] = v_drive[joint] * dir[joint];
-      } else {
+      } else if (i <= sampled_t[joint][6]) {
         v_traj[joint][i] = v_traj[joint][i-1] + t_sample_ * a_traj[joint][i];
+      } else {
+        // Set final velocity to exactly 0 (increases accuracy)
+        v_traj[joint][i] = 0.0
       }
       q_traj[joint][i] = q_traj[joint][i-1] + t_sample_ * v_traj[joint][i];
     }

--- a/src/long_term_planner.cc
+++ b/src/long_term_planner.cc
@@ -812,7 +812,12 @@ Trajectory LongTermPlanner::getTrajectory(
     q_traj[joint][0] = q_0[joint] + t_sample_ * v_traj[joint][0];
     bool phase4 = sampled_t[joint][3] - sampled_t[joint][2] > 2;
     for (int i = 1; i < traj_len; i++) {
-      a_traj[joint][i] = a_traj[joint][i-1] + t_sample_ * j_traj[joint][i];
+      if (i <= sampled_t[joint][6]) {
+        a_traj[joint][i] = a_traj[joint][i-1] + t_sample_ * j_traj[joint][i];
+      } else {
+        // Set final accelation to exactly 0 (increases accuracy)
+        a_traj[joint][i] = 0.0;
+      }
       // Set constant velocity periods to exactly v_drive (increases accuracy)
       if (phase4 && i >= sampled_t[joint][2]+1 && i< sampled_t[joint][3]-1) {
         v_traj[joint][i] = v_drive[joint] * dir[joint];
@@ -820,7 +825,7 @@ Trajectory LongTermPlanner::getTrajectory(
         v_traj[joint][i] = v_traj[joint][i-1] + t_sample_ * a_traj[joint][i];
       } else {
         // Set final velocity to exactly 0 (increases accuracy)
-        v_traj[joint][i] = 0.0
+        v_traj[joint][i] = 0.0;
       }
       q_traj[joint][i] = q_traj[joint][i-1] + t_sample_ * v_traj[joint][i];
     }

--- a/tests/randomConfiguration.m
+++ b/tests/randomConfiguration.m
@@ -1,6 +1,6 @@
 % Initialize parameters
 eps = 1e-6;
-tol = 0.01;
+tol = 0.02;
 Tsample = 0.004;
 DoF = 6;
 v_max = 1*ones(1,DoF);


### PR DESCRIPTION
**Issue:**  
In some scenarios, there remains a small velocity due to numerical inaccuracies after reaching the goal. This causes a drift in the joint angles which reduces accuracy of the planner.

**Solution:**  
Reset the velocity to zero after the last phase was completed.