### PR TITLE
Local install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ add_compile_options(-std=c++17)
 
 find_package(Eigen3 3.4 REQUIRED)
 
-#INCLUDE_DIRECTORIES ( "$ENV{EIGEN3_INCLUDE_DIR}" )
 INCLUDE_DIRECTORIES ( ${EIGEN3_INCLUDE_DIR})
 
 include_directories(
@@ -15,12 +14,46 @@ include_directories(
 
 ## Declare a C++ library
 add_library(${PROJECT_NAME}
-    src/long_term_planner.cc 
-    )
+  src/long_term_planner.cc 
+)
 
-# target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
+# Install the library
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+)
 
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+# Install the header files
+install(DIRECTORY include/
+    DESTINATION include
+)
+# Generate and install the export set for use with the install-tree
+install(EXPORT ${PROJECT_NAME}Targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION 1.0.0
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)
 
 #############
 ## GTest ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(long_term_planner)
 
 ## Compile as C++17
 add_compile_options(-std=c++17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 find_package(Eigen3 3.4 REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(${PROJECT_NAME}
 
 # target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
 
-install(TARGETS ${PROJECT_NAME} DESTINATION /usr/lib)
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
 
 #############
 ## GTest ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(long_term_planner)
 ## Compile as C++17
 add_compile_options(-std=c++17)
 
-INCLUDE_DIRECTORIES ( "$ENV{EIGEN3_INCLUDE_DIR}" )
+find_package(Eigen3 3.4 REQUIRED)
+
+#INCLUDE_DIRECTORIES ( "$ENV{EIGEN3_INCLUDE_DIR}" )
+INCLUDE_DIRECTORIES ( ${EIGEN3_INCLUDE_DIR})
 
 include_directories(
   include

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
This PR adds install rules for the LongTermPlanner.
Thereby, you can install the package with `sudo make install` and later find it with `find_package(long_term_planner)`.